### PR TITLE
(SIMP-4340) Update to puppetlabs/docker 1.0.5

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,8 +9,7 @@ fixtures:
       ref: 2.2.0
     docker:
       repo: https://github.com/simp/puppetlabs-docker
-      # requires fixes to the upstream module that have not been released yet
-      ref: 587748b6a5b140801f39cb883a1d92a4d40c662f
+      ref: 1.0.5
     iptables:
       repo: https://github.com/simp/pupmod-simp-iptables
       ref: 6.0.3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,8 @@
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    - rm -f Gemfile.lock
+    - bundle || gem install bundler
+    - rm -rf Gemfile.lock pkg/
     - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
 
 .static_tests: &static_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    - gem install bundler
     - rm -f Gemfile.lock
     - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
 
@@ -22,6 +21,7 @@
     - bundle exec rake pkg:check_version
     - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake spec
+    - bundle exec puppet module build
 
 stages:
   - unit

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,5 +1,4 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
---no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
         - bundle exec rake lint
         - bundle exec rake metadata_lint
         - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
         - bundle exec puppet module build
 
     - stage: spec
@@ -73,7 +74,7 @@ jobs:
       deploy:
         - provider: releases
           api_key:
-            secure: ~ #FIXME
+            secure: "L5HXAZ2V7fMr47rbVraSz1uzsicD9O0JjYEQXnjBSo4CjXkFO9RNX7Zpb/P7DfFMjT3NlgnG9meLD2fIX3aGUoCdP1RHXXWfGVk2A7I7wruVMf9WCqFnYpL0s/G2wLECxhL+c51iXpmpyQqSFpweLa2xE2b1xm8Gd4BKzlt+TxVY3bPr3ha6m1HUloZ8iUy7RNcRJKmm0nDmmeL1pAgTu1RdWy+smDKXVFQEL3KUiHvMm+UIVSeNeRYEUVAK+UrUo1Zquv0Mv8uwycaNhOSMyZXOMvfuFipq0KyZvXzOsI2g4kQ+XUB5OX38ztqT0O+tCFSO6CC7ZLm4dnWyaJaEhw81sITKhz1xOrONTCH3ehfLzFW9EBmuajGQCMYbCs7dNQlF4mSWSo9YjI2zEthuZ/VlHzEoJ7bSvoPLHqWp6/8wTrl2m1Y95fRyWeoayET/ef7ojPOMhOoIDdsal8ONXEFHxAeWQsxmQ8dtpD9Jc/g9RH2NawPjCeDwyc0KVh5rFQcKLbtjM4QQefdV/OZyofWnerFKX7hueKwtn3hhjvUoOdnJ4fpwLuSNyl4Pu2aXBIh2//2Bu/vbr1tfaPNEEhX+sfASIPPEdxIHRY1duKue7xQ/n5GtWEulVAam12ROBqYORJJ7TgX/3xVAqrNrU7dfBaqqVb+f/utFRTJdTqU="
           skip_cleanup: true
           on:
             tags: true
@@ -81,7 +82,7 @@ jobs:
         - provider: puppetforge
           user: simp
           password:
-            secure: ~ #FIXME
+            secure: "Spfh3CdMXqsDKlYXBHWcihPdmGG4+sJ/gVCoZ6Z2B/C2CpHC8WzwxaniVClznwI8iHYY2mZUr1BKkBIMmo2xOdJDrQ0VSecCmV912ofEvAumvy9hUR0b39Lgj6WtvZQ0ppXVX0PXbtFiJMM6Ht8vc4A8G0fVJg89qII1M372WO0rbFKpJ+Qh9xg89Z8nWUntnaoO0gl35krGjSqjZQgUuk5NZnrkVcFt+bvV2ND4QL2HZpPuwiCPets2tTa0vBR6dU74r/o+g35uz49SvULF5l1MdveDp/lZwnDiAuJ37tKhDfMZWPXvPALpix4W3r77YiaTECoRRYNFMRBJvyfL11JfsFdk4bS6/v/raJ6I89eB06oPppDohnUgPNVwBcQu2Tm3YZttW6xC92fPysZKoM9xPzq8/YBkKJ9ac1WGTcLhD7nj0mwscns+qM4PdA/ipPuqatQ4SsjxXlLUxFZ0ScwI9VR5uZOSfxLAwzVUsiaY+g/pKljA/ssXOccfUX7v1MYiD/nbT6Blj7CDsgXJf30QFeT8K/QM65tu3Vtov+VzbJUGJ1rHYz/qNyKMWgFyX/GddcH6WE8yxzQFYdQJzGbF7Ak2QM/LQ1xpIg37kfg/t525uUeucLe5jdAVdo/qFTp3UfFMzhnD7MjdSTDXuGvkPYS3m1qavEM3ICP7eqQ="
           on:
             tags: true
             rvm: 2.4.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Fri Dec 29 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.1
+* Wed Jan 31 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.1.0
+- Update to puppetlabs/docker 1.0.5
+  - Remove deprecated `manage_epel` parameter
+
+* Fri Dec 29 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
 - Ensure that the docker_group and socket_group options are the same by default
   for the 'redhat' release type
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.2')
   gem 'facterdb'
 end
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,15 +10,12 @@ simp_docker::default_options:
     use_upstream_package_source: false
     service_overrides_template: false
     selinux_enabled: "%{facts.selinux}"
-    manage_epel: false
     docker_ce_package_name: docker
     log_driver: journald
     docker_group: dockerroot
   ce:
     docker_ce_package_name: docker-ce
     log_driver: journald
-    manage_epel: false
   ee:
     docker_ee: true
     log_driver: journald
-    manage_epel: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@ class simp_docker (
   }
 
   if $iptables_docker_chain {
-    include 'iptables'
+    include '::iptables'
 
     exec { 'Add docker chain back':
       command     => '/sbin/iptables -t filter -N DOCKER',
@@ -78,7 +78,7 @@ class simp_docker (
     }
   }
 
-  class { 'docker':
-    * => $default_options[$release_type] + $_socket_group_option  + $options
+  class { '::docker':
+    * => $default_options[$release_type] + $_socket_group_option + $options
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@ class simp_docker (
   }
 
   if $iptables_docker_chain {
-    include '::iptables'
+    include 'iptables'
 
     exec { 'Add docker chain back':
       command     => '/sbin/iptables -t filter -N DOCKER',
@@ -78,7 +78,7 @@ class simp_docker (
     }
   }
 
-  class { '::docker':
+  class { 'docker':
     * => $default_options[$release_type] + $_socket_group_option + $options
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_docker",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP helper module for puppetlabs/docker",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     },
     {
       "name": "puppetlabs/docker",
-      "version_requirement": ">= 1.0.2 < 2.0.0"
+      "version_requirement": ">= 1.0.5 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/suites/ce/30_registry_spec.rb
+++ b/spec/acceptance/suites/ce/30_registry_spec.rb
@@ -55,7 +55,7 @@ describe 'docker' do
               'REGISTRY_HTTP_TLS_CERTIFICATE=/etc/pki-testing/private/#{fqdn}.pem',
               'REGISTRY_HTTP_TLS_KEY=/etc/pki-testing/private/#{fqdn}.pem',
               'REGISTRY_AUTH=htpasswd',
-              '"REGISTRY_AUTH_HTPASSWD_REALM=Beaker Realm"',
+              'REGISTRY_AUTH_HTPASSWD_REALM=Beaker Realm',
               'REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd'
             ],
             require => File['/tmp/auth/htpasswd']

--- a/spec/acceptance/suites/default/30_registry_spec.rb
+++ b/spec/acceptance/suites/default/30_registry_spec.rb
@@ -53,7 +53,7 @@ describe 'docker' do
               'REGISTRY_HTTP_TLS_CERTIFICATE=/etc/pki-testing/private/#{fqdn}.pem',
               'REGISTRY_HTTP_TLS_KEY=/etc/pki-testing/private/#{fqdn}.pem',
               'REGISTRY_AUTH=htpasswd',
-              '"REGISTRY_AUTH_HTPASSWD_REALM=Beaker Realm"',
+              'REGISTRY_AUTH_HTPASSWD_REALM=Beaker Realm',
               'REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd'
             ],
             require => File['/tmp/auth/htpasswd']

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,6 @@ describe 'simp_docker' do
             use_upstream_package_source: false,
             service_overrides_template: false,
             selinux_enabled: "true",
-            manage_epel: false,
             docker_ce_package_name: 'docker',
             log_driver: 'journald',
             docker_group: 'dockerroot',
@@ -63,7 +62,6 @@ describe 'simp_docker' do
             use_upstream_package_source: false,
             service_overrides_template: false,
             selinux_enabled: "true",
-            manage_epel: false,
             docker_ce_package_name: 'docker',
             log_driver: 'journald',
             docker_group: 'not_dockerroot',
@@ -84,7 +82,6 @@ describe 'simp_docker' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('docker').with(
             # selinux_enabled: "true",
-            manage_epel: false,
             docker_ce_package_name: 'docker-ce',
             log_driver: 'journald',
             dns: ['8.8.8.8'],


### PR DESCRIPTION
- Update to puppetlabs/docker 1.0.5
  - Remove deprecated `manage_epel` parameter
- Add secrets for releasing to to Github and the Puppet Forge

SIMP-4340 #close
SIMP-4121 #close