### PR TITLE
(SIMP-4340) Update to simp/iptables 6.1.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,7 +12,7 @@ fixtures:
       ref: 1.0.5
     iptables:
       repo: https://github.com/simp/pupmod-simp-iptables
-      ref: 6.0.3
+      ref: 6.1.1
     simplib:
       repo: https://github.com/simp/pupmod-simp-simplib
       ref: 3.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,13 @@ before_install:
   - rm -f Gemfile.lock
 
 jobs:
+  allow_failures:
+      # TODO fail on puppet 5 for now until
+      # https://github.com/rodjek/rspec-puppet/issues/647 is resolved
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
   include:
     - stage: spec
       rvm: 2.4.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 * Wed Jan 31 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.1.0
 - Update to puppetlabs/docker 1.0.5
   - Remove deprecated `manage_epel` parameter
-- Unset $iptables_docker_chain by default
+- Removed $iptables_docker_chain by default
   - The simp/iptables module has been updated so that this is not needed
 
 * Fri Dec 29 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,14 @@
 * Wed Jan 31 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.1.0
 - Update to puppetlabs/docker 1.0.5
   - Remove deprecated `manage_epel` parameter
+- Unset $iptables_docker_chain by default
+  - The simp/iptables module has been updated so that this is not needed
 
 * Fri Dec 29 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
 - Ensure that the docker_group and socket_group options are the same by default
   for the 'redhat' release type
 
-* Mon Nov 27 2017 Nick Miller <nick.miller@onyxpoint.com> - 0.0.1
+* Mon Nov 27 2017 Nick Miller <nick.miller@onyxpoint.com> - 0.1.0
 - Wrap puppetlabs/docker to:
   - Provide SIMP defaults
   - Add ease-of-use for using different distributions of Docker

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,7 +3,6 @@
 simp_docker::release_type: redhat
 simp_docker::manage_sysctl: true
 simp_docker::bridge_dev: docker0
-simp_docker::iptables_docker_chain: false
 simp_docker::options: {}
 
 simp_docker::default_options:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,7 @@
 simp_docker::release_type: redhat
 simp_docker::manage_sysctl: true
 simp_docker::bridge_dev: docker0
+simp_docker::iptables_docker_chain: false
 simp_docker::options: {}
 
 simp_docker::default_options:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,8 +37,6 @@ class simp_docker (
 
   Hash $default_options,
   Optional[Hash] $options,
-
-  Boolean $iptables_docker_chain,
 ) {
 
   # TODO: remove this block after SIMP-4261 is satisfied
@@ -66,16 +64,6 @@ class simp_docker (
         before => Class['docker'];
       'net.bridge.bridge-nf-call-iptables':  value => 1 ;
       'net.bridge.bridge-nf-call-ip6tables': value => 1 ;
-    }
-  }
-
-  if $iptables_docker_chain {
-    include 'iptables'
-
-    exec { 'Add docker chain back':
-      command     => '/sbin/iptables -t filter -N DOCKER',
-      refreshonly => true,
-      subscribe   => Class['iptables']
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,10 +24,6 @@
 #
 #   This parameter will overwrite and default setting in $default_options.
 #
-# @param iptables_docker_chain Add the `DOCKER` chain back when the iptables
-#   rules have been changed by simp/iptables. When using a version of
-#   simp/iptables module older than 6.1.1, this will need to be set to true.
-#
 # @author https://github.com/simp/pupmod-simp-simp_docker/graphs/contributors
 #
 class simp_docker (

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,8 +24,9 @@
 #
 #   This parameter will overwrite and default setting in $default_options.
 #
-# @param iptables_docker_chain If using the SIMP iptables module, add the
-#   `DOCKER` chain back when the iptables rules have been changed by Puppet.
+# @param iptables_docker_chain Add the `DOCKER` chain back when the iptables
+#   rules have been changed by simp/iptables. When using a version of
+#   simp/iptables module older than 6.1.1, this will need to be set to true.
 #
 # @author https://github.com/simp/pupmod-simp-simp_docker/graphs/contributors
 #
@@ -37,7 +38,7 @@ class simp_docker (
   Hash $default_options,
   Optional[Hash] $options,
 
-  Boolean $iptables_docker_chain = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
+  Boolean $iptables_docker_chain,
 ) {
 
   # TODO: remove this block after SIMP-4261 is satisfied

--- a/spec/acceptance/suites/ce/10_one_node_spec.rb
+++ b/spec/acceptance/suites/ce/10_one_node_spec.rb
@@ -29,6 +29,10 @@ describe 'docker using redhat provided packages' do
 
         apply_manifest_on(host, manifest, run_in_parallel: true)
         apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
+      end
+
+      it 'should be idempotent' do
+        sleep 20
         apply_manifest_on(host, manifest, catch_changes: true, run_in_parallel: true)
       end
 

--- a/spec/acceptance/suites/ce/10_one_node_spec.rb
+++ b/spec/acceptance/suites/ce/10_one_node_spec.rb
@@ -27,7 +27,6 @@ describe 'docker using redhat provided packages' do
 
         on(host, 'yum install -y epel-release', run_in_parallel: true)
 
-        set_hieradata_on(host, { 'simp_options::firewall' => true })
         apply_manifest_on(host, manifest, run_in_parallel: true)
         apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
         apply_manifest_on(host, manifest, catch_changes: true, run_in_parallel: true)

--- a/spec/acceptance/suites/ce/20_multi_node_spec.rb
+++ b/spec/acceptance/suites/ce/20_multi_node_spec.rb
@@ -31,6 +31,8 @@ describe 'docker' do
     hosts.each do |host|
       it 'should apply with no errors' do
         apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
+        apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
+        sleep 20
         apply_manifest_on(host, manifest, catch_changes: true, run_in_parallel: true)
       end
 
@@ -54,8 +56,8 @@ describe 'docker' do
         apply_manifest_on(host, run_manifest, catch_failures: true, run_in_parallel: true)
         sleep 20
         apply_manifest_on(host, run_manifest, catch_changes: true, run_in_parallel: true)
-        result = retry_on(host, 'curl localhost:80', verbose: true).stdout
-        expect(result).to match(/Hello from Docker on SIMP/)
+        result = retry_on(host, 'curl localhost:80', verbose: true)
+        expect(result.stdout).to match(/Hello from Docker on SIMP/)
       end
     end
   end

--- a/spec/acceptance/suites/default/10_one_node_spec.rb
+++ b/spec/acceptance/suites/default/10_one_node_spec.rb
@@ -30,6 +30,7 @@ describe 'docker using redhat provided packages' do
       end
 
       it 'should be idempotent' do
+        sleep 20
         apply_manifest_on(host, manifest, catch_changes: true, run_in_parallel: true)
       end
 

--- a/spec/acceptance/suites/default/10_one_node_spec.rb
+++ b/spec/acceptance/suites/default/10_one_node_spec.rb
@@ -25,7 +25,6 @@ describe 'docker using redhat provided packages' do
 
         on(host, 'yum install -y epel-release', run_in_parallel: true)
 
-        set_hieradata_on(host, { 'simp_options::firewall' => true })
         apply_manifest_on(host, manifest, run_in_parallel: true)
         apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
       end

--- a/spec/acceptance/suites/default/20_multi_node_spec.rb
+++ b/spec/acceptance/suites/default/20_multi_node_spec.rb
@@ -29,6 +29,8 @@ describe 'docker' do
     hosts.each do |host|
       it 'should apply with no errors' do
         apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
+        apply_manifest_on(host, manifest, catch_failures: true, run_in_parallel: true)
+        sleep 20
         apply_manifest_on(host, manifest, catch_changes: true, run_in_parallel: true)
       end
 
@@ -52,8 +54,8 @@ describe 'docker' do
         apply_manifest_on(host, run_manifest, catch_failures: true, run_in_parallel: true)
         sleep 20
         apply_manifest_on(host, run_manifest, catch_changes: true, run_in_parallel: true)
-        result = retry_on(host, 'curl localhost:80', verbose: true).stdout
-        expect(result).to match(/Hello from Docker on SIMP/)
+        result = retry_on(host, 'curl localhost:80', verbose: true)
+        expect(result.stdout).to match(/Hello from Docker on SIMP/)
       end
     end
   end


### PR DESCRIPTION
- Unset $iptables_docker_chain by default
  - The simp/iptables module has been updated so that this is not needed