### PR TITLE
(SIMP-4897) Update to puppetlabs/docker 1.1.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,21 +1,12 @@
 ---
 fixtures:
   repositories:
-    augeasproviders_core:
-      repo: https://github.com/simp/augeasproviders_core
-      ref: 2.1.4
-    augeasproviders_sysctl:
-      repo: https://github.com/simp/augeasproviders_sysctl
-      ref: 2.2.0
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
     docker:
       repo: https://github.com/simp/puppetlabs-docker
-      ref: 1.0.5
-    iptables:
-      repo: https://github.com/simp/pupmod-simp-iptables
-      ref: 6.1.1
-    simplib:
-      repo: https://github.com/simp/pupmod-simp-simplib
-      ref: 3.8.0
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
-      ref: 4.19.0
+      tag: 1.1.0
+    iptables: https://github.com/simp/pupmod-simp-iptables
+    simplib:  https://github.com/simp/pupmod-simp-simplib
+    stdlib: https://github.com/simp/puppetlabs-stdlib
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,27 +2,34 @@
 .cache_bundler: &cache_bundler
   cache:
     untracked: true
-    key: "$CI_BUILD_REF_NAME"
+    # A broad attempt at caching between runs (ala Travis CI)
+    key: "${CI_PROJECT_NAMESPACE}__bundler"
     paths:
       - '.vendor'
       - 'vendor'
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    - bundle || gem install bundler
-    - rm -rf pkg/
-    - bundle update --no-binstubs --path .vendor "${FLAGS[@]}" puppet
-    - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
+    - 'echo Files in cache: $(find .vendor | wc -l) || :'
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
 
-.static_tests: &static_tests
+
+.validation_checks: &validation_checks
   script:
     - bundle exec rake syntax
-    - bundle exec rake lint
     - bundle exec rake check:dot_underscore
     - bundle exec rake check:test_file
     - bundle exec rake pkg:check_version
     - bundle exec rake pkg:compare_latest_tag
-    - bundle exec rake spec
+    - bundle exec rake lint
+    - bundle exec rake clean
     - bundle exec puppet module build
 
 stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,8 @@
 .setup_bundler_env: &setup_bundler_env
   before_script:
     - bundle || gem install bundler
-    - rm -rf Gemfile.lock pkg/
+    - rm -rf pkg/
+    - bundle update --no-binstubs --path .vendor "${FLAGS[@]}" puppet
     - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
 
 .static_tests: &static_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ puppet-gemfile:
   image: ruby:2.1.9
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *static_tests
+  <<: *validation_checks
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
@@ -58,7 +58,7 @@ puppet-4.7:
     PUPPET_VERSION: '4.7'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *static_tests
+  <<: *validation_checks
 
 puppet-5:
   stage: unit
@@ -69,7 +69,7 @@ puppet-5:
     PUPPET_VERSION: '5.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *static_tests
+  <<: *validation_checks
 
 
 default:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed May 09 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.1.1
+- Update to puppetlabs/docker 1.1.0
+  - $selinux_enabled changed from taking string to only taking booleans, 
+    breaking the hiera interpolation trick that was used to set that parameter
+    to the selinux status of the system.
+
 * Wed Jan 31 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.1.0
 - Update to puppetlabs/docker 1.0.5
   - Remove deprecated `manage_epel` parameter

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -9,7 +9,6 @@ simp_docker::default_options:
   redhat:
     use_upstream_package_source: false
     service_overrides_template: false
-    selinux_enabled: "%{facts.selinux}"
     docker_ce_package_name: docker
     log_driver: journald
     docker_group: dockerroot

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,21 @@ class simp_docker (
     $_socket_group_option = {}
   }
 
+  # The 'selinux_enabled' parameter should be set to the state of the system,
+  # but only if using the 'redhat' release_type
+  case $release_type {
+    'redhat': {
+      $_default_options = $default_options[$release_type].merge(
+        {
+          'selinux_enabled' => $facts['selinux']
+        }
+      )
+    }
+    default: {
+      $_default_options = $default_options[$release_type]
+    }
+  }
+
   $_docker_bridge_up = ($bridge_dev in $facts['networking']['interfaces'].keys)
   if $manage_sysctl and $_docker_bridge_up {
     sysctl {
@@ -64,6 +79,6 @@ class simp_docker (
   }
 
   class { 'docker':
-    * => $default_options[$release_type] + $_socket_group_option + $options
+    * => $_default_options + $_socket_group_option + $options
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_docker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "SIMP Team",
   "summary": "A SIMP helper module for puppetlabs/docker",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     },
     {
       "name": "puppetlabs/docker",
-      "version_requirement": ">= 1.0.5 < 2.0.0"
+      "version_requirement": ">= 1.1.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,6 +13,7 @@ describe 'simp_docker' do
               em1: nil
             }
           }
+          facts[:selinux] = true
           facts
         end
 
@@ -21,7 +22,7 @@ describe 'simp_docker' do
           it { is_expected.to contain_class('docker').with(
             use_upstream_package_source: false,
             service_overrides_template: false,
-            selinux_enabled: "true",
+            selinux_enabled: true,
             docker_ce_package_name: 'docker',
             log_driver: 'journald',
             docker_group: 'dockerroot',


### PR DESCRIPTION
- In puppetlabs/docker 1.1.0, $selinux_enabled changed from taking
  string to only taking booleans, breaking the hiera interpolation trick
  that was used to set that parameter to the selinux status of the
  system.

SIMP-4897 #close